### PR TITLE
web.config - Information disclosue vulnerability

### DIFF
--- a/images/nginx-drupal/drupal.conf
+++ b/images/nginx-drupal/drupal.conf
@@ -27,7 +27,7 @@ server {
     ## Replicate the Apache <FilesMatch> directive of Drupal standard
     ## .htaccess. Disable access to any code files. Return a 404 to curtail
     ## information disclosure.
-    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|.*sql\.gz|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|.*sql\.gz|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^\/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save|web\.config)$ {
       deny all;
       access_log off;
       log_not_found off;


### PR DESCRIPTION
Penetration testing revealed the possibility of information disclosure on the web.config file.

A threat actor performing reconnaissance on the application would look for any known vulnerabilities against an application via its reported software type and version. As things become outdated and vulnerable, an attacker will seek to exploit these vulnerabilities if they are aware of the software versions in use.
